### PR TITLE
support jetson(aarch64)

### DIFF
--- a/archdefs.mk
+++ b/archdefs.mk
@@ -14,7 +14,7 @@
 #
 # Reproduced from PATH_TO_GIGE-V_FRAMEWORK/DALSA/GigeV/examples/genicam_c_demo  
 ifndef ARCH
-  ARCH := $(shell uname -m | sed -e s/i.86/i386/ -e s/x86_64/x86_64/ -e s/armv5.*/armv5/ -e s/armv6.*/armv6/ -e s/armv7.*/armv7/)
+  ARCH := $(shell uname -m | sed -e s/i.86/i386/ -e s/x86_64/x86_64/ -e s/armv5.*/armv5/ -e s/armv6.*/armv6/ -e s/armv7.*/armv7/ -e s/aarch64/aarch64/)
 endif
 
 ifeq  ($(ARCH), x86_64)
@@ -29,12 +29,25 @@ ifeq  ($(ARCH), i386)
 	ARCH_OPTIONS= -D__i386__ -D_REENTRANT
 	ARCH_GCCVER=421
 else
+ifeq  ($(ARCH), aarch64)
+	# Very Old
+	ARCHNAME=armv8-a
+	ARCH_GENICAM_BIN=Linux64_ARM
+	ARCH_OPTIONS= -D__arm__ -D_REENTRANT
+	ARCH_GCCVER=54
+else
 # Not supported
 $(error Architecture $(ARCH) not configured for this installation.)
 endif
 endif
+endif
 
+ifeq  ($(ARCH), aarch64)
+ARCHLIBDIR=/usr/lib/aarch64-linux-gnu
+ARCH_LINK_OPTIONS=
+else
 ARCHLIBDIR=/usr/lib
+endif
 
 #
 # Arch dependent GenICam library specification


### PR DESCRIPTION
Hello, thanks for this useful software !
Currently, I could work genie nano c1280(aarch64) for Jetson Xavier NX, I added the modification for aarch64 to archdefs.mk.
I have been wondering how to process the image for Geinie Nano with opencv. I solved it thanks to Mr. Aaron Fishman.